### PR TITLE
Add IO::Socket::SSL prereq

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -15,3 +15,4 @@ requires 'Devel::Cover', 1.02;
 requires 'JSON::PP';
 requires 'YAML';
 requires 'Furl';
+requires 'IO::Socket::SSL';


### PR DESCRIPTION
IO::Socket::SSL is needed by Furl to make HTTPS connections, but it isn't a hard requirement.  This module submits over HTTPS, so include it as a dep here.
