### PR TITLE
Use core HTTP::Tiny instead of Furl

### DIFF
--- a/META.json
+++ b/META.json
@@ -47,9 +47,11 @@
       "runtime" : {
          "requires" : {
             "Devel::Cover" : "1.02",
-            "Furl" : "0",
-            "IO::Socket::SSL" : "0",
+            "HTTP::Tiny" : "0",
+            "IO::Socket::SSL" : "1.42",
             "JSON::PP" : "0",
+            "Mozilla::CA" : "0",
+            "Net::SSLeay" : "1.49",
             "YAML" : "0",
             "perl" : "5.008005"
          }

--- a/cpanfile
+++ b/cpanfile
@@ -12,7 +12,9 @@ on 'develop' => sub {
 };
 
 requires 'Devel::Cover', 1.02;
+requires 'HTTP::Tiny';
+requires 'IO::Socket::SSL', 1.42;
 requires 'JSON::PP';
+requires 'Mozilla::CA';
+requires 'Net::SSLeay', 1.49;
 requires 'YAML';
-requires 'Furl';
-requires 'IO::Socket::SSL';

--- a/lib/Devel/Cover/Report/Coveralls.pm
+++ b/lib/Devel/Cover/Report/Coveralls.pm
@@ -9,9 +9,9 @@ our $API_ENDPOINT = 'https://coveralls.io/api/v1/jobs';
 our $SERVICE_NAME = 'coveralls-perl';
 
 use Devel::Cover::DB;
+use HTTP::Tiny;
 use JSON::PP;
 use YAML;
-use Furl;
 
 sub get_source {
     my ($file, $callback) = @_;
@@ -116,13 +116,14 @@ sub report {
     $json->{git} = eval { get_git_info() } || {};
     $json->{source_files} = \@sfs;
 
-    my $furl = Furl->new;
-    my $response = $furl->post($API_ENDPOINT, [], [ json => encode_json $json ]);
+    my $response = HTTP::Tiny->new( verify_SSL => 1 )
+        ->post_form( $API_ENDPOINT, { json => encode_json $json } );
 
-    my $res = eval { decode_json($response->content); };
+    my $res = eval { decode_json $response->{content} };
+
     if ($@) {
-        print "error: " . $response->content;
-    } elsif ($response->is_success) {
+        print "error: " . $response->{content};
+    } elsif ($response->{success}) {
         print "register: " . $res->{url} . "\n";
     } else {
         print "error: " . $res->{message} . "\n";


### PR DESCRIPTION
Given that under Travis this module is installed for every test run, reducing it's dependencies can have a measurable effect on test run time.

HTTP::Tiny, unlike Furl is in core, by swapping the two modules we no longer need to install Furl or it's dependencies of Class::Accessor::Lite & HTTP::Parser::XS.

IO::Socket::SSL >= 1.42 & Net::SSLeay >= 1.49 are required for SSL support in HTTP::Tiny.

HTTP::Tiny by default won't check certificates, by installing Mozilla::CA and setting verify_SSL at construction time we get the same level of experience as Furl, with Coverall's certificate being checked against the Mozilla database.

Next step, it's annoying that Devel::Cover installs CGI, especially given we're not even using the HTML reports :-P
