### PR TITLE
Support Github Actions (Easiest way to report from master)

### DIFF
--- a/lib/Devel/Cover/Report/Coveralls.pm
+++ b/lib/Devel/Cover/Report/Coveralls.pm
@@ -88,6 +88,9 @@ sub get_config {
     } elsif ($ENV{JENKINS_URL}) {
         $json->{service_name} = 'jenkins';
         $json->{service_number} = $ENV{BUILD_NUM};
+    } elsif ($ENV{GITHUB_ACTIONS} && $ENV{GITHUB_SHA}) {
+        $json->{service_name}   = 'github-actions';
+        $json->{service_number} = substr($ENV{GITHUB_SHA}, 0, 9);
     } else {
         $is_travis = 0;
         $json->{service_name} = $config->{service_name} || $SERVICE_NAME;


### PR DESCRIPTION
* When I just set `github` to `service_name` , I got `error: Couldn't find a repository matching this job.` from Coveralls somehow.
    * I avoid the error to set `github-actions` instead of `github`
* Github Actions doesn't have incremental number as ENV
    * Coveralls is acceptable SHA as service_number

