### PR TITLE
"github" instead of "github-actions" for service_name

### DIFF
--- a/lib/Devel/Cover/Report/Coveralls.pm
+++ b/lib/Devel/Cover/Report/Coveralls.pm
@@ -93,7 +93,7 @@ sub get_config {
         $json->{service_name} = 'jenkins';
         $json->{service_number} = $ENV{BUILD_NUM};
     } elsif ($ENV{GITHUB_ACTIONS} && $ENV{GITHUB_SHA}) {
-        $json->{service_name}   = 'github-actions';
+        $json->{service_name}   = 'github';
         $json->{service_number} = substr($ENV{GITHUB_SHA}, 0, 9);
     } else {
         $is_travis = 0;


### PR DESCRIPTION
There is no description on the official document ( https://docs.coveralls.io/api-introduction ), but the service_name when using coveralls from GitHub Actions seems "github". This can be inferred from the following coveralls official implementation.

https://github.com/coverallsapp/github-action/blob/master/lib/run.js#L30