### PR TITLE
Remove the Travis CI badge

### DIFF
--- a/minil.toml
+++ b/minil.toml
@@ -1,5 +1,5 @@
 name = "Devel-Cover-Report-Coveralls"
-badges = ['github-actions/master', 'github-actions/windows', 'github-actions/mac', 'travis']
+badges = ['github-actions/master', 'github-actions/windows', 'github-actions/mac']
 markdown_maker = "Pod::Markdown::Github"
 [FileGatherer]
 exclude_match = ["^docker-compose*"]


### PR DESCRIPTION
This PR removes the no longer working Travis CI badge from the README.md file.

There's still a dangling link in the Travis CI section: `<img src="http://kan.github.io/images/p5-ltsv.png" />`