### PR TITLE
Run the coverage test with DEVEL_COVER_SELF

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -25,10 +25,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+      - name: Configure git
+        run: git config --system --add safe.directory '*'
       - name: perl -V
         run: perl -V
       - name: Install dependencies
-        run: curl -sL https://git.io/cpm | perl - install -g --with-recommends --with-test --with-configure --show-build-log-on-failure
+        run: cpanm --quiet --notest --installdeps --with-recommends --with-configure .
       - name: Run build
         run: |
             perl Build.PL
@@ -40,5 +42,6 @@ jobs:
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
         run: |
             ./Build install
-            cover -test -report coveralls
+            HARNESS_PERL_SWITCHES=-MDevel::Cover DEVEL_COVER_SELF=1 ./Build test
+            cover -report coveralls
         if: matrix.perl-version == 'latest'


### PR DESCRIPTION
Devel::Cover [ignores modules](https://github.com/pjcj/Devel--Cover/blob/e7b9fb420589b8e84788eebea8987ac2a4c92948/lib/Devel/Cover.pm#L146) that match the regular expression `/Devel/Cover[./]` unless the environment variable DEVEL_COVER_SELF is defined. This PR sets the environment variable for the GitHub Actions step "Run Cover".

The PR also sets the Git option `safe.directory`, which currently needs to be set in Docker images that run the git command in GitHub Actions. See https://github.blog/2022-04-12-git-security-vulnerability-announced/ for more information.

The "Run Cover" step does now output and upload the coverage report.

```
---------------------------- ------ ------ ------ ------ ------ ------ ------
File                           stmt   bran   cond    sub    pod   time  total
---------------------------- ------ ------ ------ ------ ------ ------ ------
...Cover/Report/Coveralls.pm   63.7   42.4   44.8   80.0    0.0  100.0   55.6
Total                          63.7   42.4   44.8   80.0    0.0  100.0   55.6
---------------------------- ------ ------ ------ ------ ------ ------ ------
```